### PR TITLE
Fix video playback reset on orientation change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
       </intent-filter>
     </activity>
     <activity android:name=".activity.ActionActivity"/>
-    <activity android:name=".activity.VideoActivity"/>
+    <activity android:name=".activity.VideoActivity" android:configChanges="orientation|screenSize"/>
     <activity android:name=".activity.QuizActivity" android:configChanges="orientation|screenSize"/>
     <activity android:name=".activity.TopicActivity"/>
   </application>


### PR DESCRIPTION
If you're playing a video then rotate your screen it resets the video progress, this fixes that bug.